### PR TITLE
mainブランチへのPR作成時は通知OFF

### DIFF
--- a/.github/workflows/discord-pr-notification.yml
+++ b/.github/workflows/discord-pr-notification.yml
@@ -3,6 +3,8 @@ name: Discord PR Notification
 on:
   pull_request:
     types: [opened] # PRが作成された時のみ実行
+    branches-ignore:
+      - main # メインブランチへのPRは通知しない
 
 jobs:
   notify:


### PR DESCRIPTION
mainブランチに対してのPRは、基本的にDeployのためのPRしかないのでいちいち通知を入れたくない